### PR TITLE
Adding RAGEngine Support

### DIFF
--- a/pr_agent/clients/kaito_rag_client.py
+++ b/pr_agent/clients/kaito_rag_client.py
@@ -1,0 +1,109 @@
+import requests
+import json
+
+class KAITORagClient:
+    def __init__(self, base_url):
+        self.base_url = base_url
+        self.headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json"
+        }
+
+    def index_documents(self, index_name, documents):
+        """
+        Index documents in the RAGEngine.
+        documents: list of dicts, each with 'text' and optional 'metadata'
+        """
+        url = f"{self.base_url}/index"
+        payload = {
+            "index_name": index_name,
+            "documents": documents
+        }
+        print(f"Indexing documents to {url} with payload: {payload}")
+        resp = requests.post(url, json=payload, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def query(self, index_name, query, llm_temperature, llm_max_tokens, top_k=5):
+        """
+        Query the RAGEngine.
+        query: str, the query text
+        top_k: int, number of results to return
+        metadata: optional dict, additional metadata for the query
+        """
+        url = f"{self.base_url}/query"
+        payload = {
+            "index_name": index_name,
+            "query": query,
+            "top_k": top_k,
+            "llm_params": {
+                "temperature": llm_temperature,
+                "max_tokens": llm_max_tokens
+            }
+        }
+        resp = requests.post(url, json=payload, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def update_documents(self, index_name, documents):
+        """
+        Update a document in the RAGEngine.
+        documents: list of dicts, each with 'id', 'text', and optional 'metadata'
+        """
+        url = f"{self.base_url}/indexes/{index_name}/documents"
+        payload = {"documents": documents}
+        resp = requests.post(url, json=payload, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def delete_documents(self, index_name, document_ids):
+        """
+        Delete a document from the RAGEngine by its ID.
+        """
+        url = f"{self.base_url}/indexes/{index_name}/documents/delete"
+        payload = {"doc_ids": document_ids}
+        resp = requests.post(url, json=payload, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def list_documents(self, index_name, metadata_filter, limit=10, offset=0):
+        """
+        List documents in the RAGEngine.
+        """
+        url = f"{self.base_url}/indexes/{index_name}/documents"
+        params = {"limit": limit, "offset": offset }
+        if metadata_filter:
+            params["metadata_filter"] = json.dumps(metadata_filter)
+        print(f"Listing documents from {url} with params: {params}")
+        resp = requests.get(url, headers=self.headers, params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    def list_indexes(self):
+        """
+        List all indexes in the RAGEngine.
+        """
+        url = f"{self.base_url}/indexes"
+        resp = requests.get(url, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def persist_index(self, index_name, path="/tmp"):
+        """
+        Persist an index in the RAGEngine.
+        """
+        url = f"{self.base_url}/persist/{index_name}"
+        params = {"path": path}
+        resp = requests.post(url, params=params, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def load_index(self, index_name, path="/tmp", overwrite=True):
+        """
+        Load an index in the RAGEngine.
+        """
+        url = f"{self.base_url}/load/{index_name}"
+        params = {"path": path, "overwrite": overwrite}
+        resp = requests.post(url, params=params, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -36,6 +36,7 @@ from pr_agent.identity_providers import get_identity_provider
 from pr_agent.identity_providers.identity_provider import Eligibility
 from pr_agent.log import LoggingFormat, get_logger, setup_logger
 from pr_agent.servers.utils import DefaultDictWithTimeout, verify_signature
+from pr_agent.tools.pr_rag_engine import PRRagEngine
 
 setup_logger(fmt=LoggingFormat.JSON, level=get_settings().get("CONFIG.LOG_LEVEL", "DEBUG"))
 base_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -46,6 +47,8 @@ if os.path.exists(build_number_path):
 else:
     build_number = "unknown"
 router = APIRouter()
+use_rag_engine = get_settings().get("CONFIG.USE_RAG_ENGINE", False)
+ragEngine = PRRagEngine(base_url=get_settings().get("CONFIG.RAG_ENGINE_URL", ""))
 
 
 @router.post("/api/v1/github_webhooks")
@@ -167,6 +170,12 @@ async def handle_new_pr_opened(body: Dict[str, Any],
         # logic to ignore PRs with specific titles (e.g. "[Auto] ...")
         apply_repo_settings(api_url)
         if get_identity_provider().verify_eligibility("github", sender_id, api_url) is not Eligibility.NOT_ELIGIBLE:
+            get_logger().info(f"Processing new PR {api_url=}, action={action}, title={title}")
+            if use_rag_engine:
+                try:
+                    ragEngine.create_new_pr_index(api_url)
+                except Exception as e:
+                    get_logger().error(f"Failed to create new PR index for {api_url=}: {e}")
             await _perform_auto_commands_github("pr_commands", agent, body, api_url, log_context)
         else:
             get_logger().info(f"User {sender=} is not eligible to process PR {api_url=}")
@@ -226,6 +235,11 @@ async def handle_push_trigger_for_new_commits(body: Dict[str, Any],
     try:
         if get_identity_provider().verify_eligibility("github", sender_id, api_url) is not Eligibility.NOT_ELIGIBLE:
             get_logger().info(f"Performing incremental review for {api_url=} because of {event=} and {action=}")
+            if use_rag_engine:
+                try:
+                    ragEngine.update_index(api_url)
+                except Exception as e:
+                    get_logger().error(f"Failed to update PR index for {api_url=}: {e}")
             await _perform_auto_commands_github("push_commands", agent, body, api_url, log_context)
 
     finally:
@@ -241,10 +255,15 @@ def handle_closed_pr(body, event, action, log_context):
     if not is_merged:
         return
     api_url = pull_request.get("url", "")
-    pr_statistics = get_git_provider()(pr_url=api_url).calc_pr_statistics(pull_request)
-    log_context["api_url"] = api_url
-    get_logger().info("PR-Agent statistics for closed PR", analytics=True, pr_statistics=pr_statistics, **log_context)
-
+    if get_settings().get("CONFIG.ANALYTICS_FOLDER", ""):
+        pr_statistics = get_git_provider()(pr_url=api_url).calc_pr_statistics(pull_request)
+        log_context["api_url"] = api_url
+        get_logger().info("PR-Agent statistics for closed PR", analytics=True, pr_statistics=pr_statistics, **log_context)
+    if use_rag_engine:
+        try:
+            ragEngine.update_base_branch_index(api_url)
+        except Exception as e:
+            get_logger().error(f"Failed to update base branch index for {api_url=}: {e}")
 
 def get_log_context(body, event, action, build_number):
     sender = ""
@@ -401,8 +420,7 @@ async def handle_request(body: Dict[str, Any], event: str):
     elif event == 'pull_request' and action == 'synchronize':
         await handle_push_trigger_for_new_commits(body, event, sender,sender_id,  action, log_context, agent)
     elif event == 'pull_request' and action == 'closed':
-        if get_settings().get("CONFIG.ANALYTICS_FOLDER", ""):
-            handle_closed_pr(body, event, action, log_context)
+        handle_closed_pr(body, event, action, log_context)
     else:
         get_logger().info(f"event {event=} action {action=} does not require any handling")
     return {}

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -67,6 +67,8 @@ auto_approve_for_no_suggestions=false # If true, the PR will be auto-approved if
 enable_claude_extended_thinking = false # Set to true to enable extended thinking feature
 extended_thinking_budget_tokens = 2048
 extended_thinking_max_output_tokens = 4096
+use_rag_engine = false
+rag_engine_url=""
 
 
 [pr_reviewer] # /review #

--- a/pr_agent/tools/pr_rag_engine.py
+++ b/pr_agent/tools/pr_rag_engine.py
@@ -1,0 +1,239 @@
+from pr_agent.clients.kaito_rag_client import KAITORagClient
+from pr_agent.git_providers import (get_git_provider,
+                                    get_git_provider_with_context)
+from pr_agent.algo.types import EDIT_TYPE
+
+from ..log import get_logger
+import base64
+
+
+class PRRagEngine:
+    def __init__(self, base_url: str):
+        self.rag_client = KAITORagClient(base_url)
+        # these are the languages that are supported by tree sitter
+        self.valid_languages = ['bash', 'c', 'c_sharp','commonlisp', 'cpp', 'css', 'dockerfile', 'dot', 'elisp', 'elixir', 'elm', 'embedded_template', 'erlang', 'fixed_form_fortran', 'fortran', 'go', 'gomod', 'hack', 'haskell', 'hcl', 'html', 'java', 'javascript', 'jsdoc', 'json', 'julia', 'kotlin', 'lua', 'make', 'markdown', 'objc', 'ocaml', 'perl', 'php', 'python', 'ql', 'r', 'regex', 'rst', 'ruby', 'rust', 'scala', 'sql', 'sqlite', 'toml', 'tsq', 'typescript', 'yaml']
+
+    def _get_git_provider(self, pr_url: str):
+        git_provider = get_git_provider(pr_url)
+        if not git_provider:
+            get_logger().error(f"Git provider not found for PR URL {pr_url}.")
+            raise ValueError("Git provider not found for the given PR URL.")
+        return git_provider
+
+    def _get_index_name(self, git_provider):
+        if not git_provider:
+            raise ValueError("Git provider not found for the given PR URL.")
+
+        # Build index_name from repo and branch
+        repo_name = git_provider.repo.replace('/', '_')
+        branch_name = git_provider.get_pr_branch().replace('/', '_')
+        index_name = f"{repo_name}_{branch_name}"
+        return index_name
+    
+    def _get_default_branch_index_name(self, git_provider):
+        if not git_provider:
+            raise ValueError("Git provider not found for the given PR URL.")
+
+        # Build index_name from repo and branch
+        repo_name = git_provider.repo.replace('/', '_')
+        branch_name = git_provider.repo_obj.default_branch.replace('/', '_')
+        index_name = f"{repo_name}_{branch_name}"
+        return index_name
+
+    def _does_index_exist(self, index_name: str):
+        try:
+            resp = self.rag_client.list_indexes()
+            if resp and index_name in resp:
+                return True
+        except Exception as e:
+            get_logger().error(f"Error checking index existence: {e}")
+            raise e
+        return False
+    
+    def update_base_branch_index(self, pr_url: str):
+        try:
+            # Update the base branch index
+            get_logger().info(f"Updating base branch index {pr_url}.")
+            self.update_index(pr_url, for_base_branch=True)
+        except Exception as e:
+            get_logger().error(f"Error updating base branch index: {e}")
+            raise e
+
+    def create_base_branch_index(self, pr_url: str):
+        git_provider = get_git_provider_with_context(pr_url)
+        if not git_provider:
+            get_logger().error(f"Git provider not found for PR URL {pr_url}.")
+            raise ValueError("Git provider not found for the given PR URL.")
+
+        index_name = self._get_default_branch_index_name(git_provider)
+        print(f"Creating base branch index {index_name} for PR URL {pr_url}.")
+
+        # Check if the index already exists
+        if self._does_index_exist(index_name):
+            get_logger().info(f"Index {index_name} already exists. Skipping creation.")
+            return
+
+        default_branch = git_provider.repo_obj.get_branch(git_provider.repo_obj.default_branch)
+        if not default_branch:
+            get_logger().error(f"Default branch {git_provider.repo_obj.default_branch} not found.")
+            raise ValueError("Default branch not found for the given PR URL.")
+        
+        base_branch_tree = git_provider.repo_obj.get_git_tree(default_branch.commit.sha, recursive=True)
+        batch_docs = []
+        for file_info in base_branch_tree.tree:
+            if file_info.type == "blob":
+                # Might want to check file size / or other attributes here for filtering
+                print(f"Indexing file {file_info.path} with sha {file_info.sha}")
+                doc = {
+                    "text": base64.b64decode(git_provider.repo_obj.get_git_blob(file_info.sha).content).decode(),
+                    "metadata": {
+                        "file_name": file_info.path,
+                    }
+                }
+                print(f"Document created for file {file_info.path}: {doc}")
+                batch_docs.append(doc)
+                # no language info here yet
+                # need to check file extensions go get it
+            if len(batch_docs) >= 10:
+                try:
+                    self.rag_client.index_documents(index_name, batch_docs)
+                except Exception as e:
+                    get_logger().error(f"Error indexing documents: {e}")
+                batch_docs = []
+        if batch_docs:
+            try:
+                resp = self.rag_client.index_documents(index_name, batch_docs)
+            except Exception as e:
+                get_logger().error(f"Error indexing documents: {e}")
+                raise e
+
+
+    def create_new_pr_index(self, pr_url: str):
+        git_provider = get_git_provider_with_context(pr_url)
+        if not git_provider:
+            get_logger().error(f"Git provider not found for PR URL {pr_url}.")
+            raise ValueError("Git provider not found for the given PR URL.")
+
+        index_name = self._get_index_name(git_provider)
+        base_index_name = self._get_default_branch_index_name(git_provider)
+
+        try:
+            # Check if the base branch index already exists
+            if not self._does_index_exist(base_index_name):
+                self.create_base_branch_index(pr_url)
+
+            # On create calls we will always overwrite the index in case of branch reusage
+            get_logger().info(f"Creating new index {index_name} for PR URL {pr_url}.")
+            self.rag_client.persist_index(base_index_name, path=f"/tmp/{base_index_name}")
+            self.rag_client.load_index(index_name, path=f"/tmp/{base_index_name}", overwrite=True)
+            
+            self.update_index(pr_url)
+
+        except Exception as e:
+            get_logger().error(f"Error creating new pr index: {e}")
+            raise e
+
+    def update_index(self, pr_url: str, for_base_branch: bool = False):
+        git_provider = get_git_provider_with_context(pr_url)
+        if not git_provider:
+            get_logger().error(f"Git provider not found for PR URL {pr_url}.")
+            raise ValueError("Git provider not found for the given PR URL.")
+
+        index_name = self._get_index_name(git_provider)
+        base_index_name = self._get_default_branch_index_name(git_provider)
+
+        try:
+            diff_files = git_provider.get_diff_files()
+            deleted_docs = []
+            update_docs = []
+            create_docs = []
+            existing_docs = []
+            for file_info in diff_files:
+                resp = self.rag_client.list_documents(index_name, metadata_filter={"file_name": file_info.filename})
+                if resp and resp.get("documents"):
+                    existing_docs.extend(resp["documents"])
+
+            for file_info in diff_files:
+                doc = {
+                    "text": file_info.head_file,
+                    "metadata": {
+                        "file_name": file_info.filename,
+                    }
+                }
+
+                if file_info.language and file_info.language in self.valid_languages:
+                    # will likely need to make a map of github languages to tree sitter languages
+                    doc["metadata"]["language"] = file_info.language
+                    doc["metadata"]["split_type"] = "code"
+                
+                curr_doc = None
+                for existing_doc in existing_docs:
+                    if file_info.filename == existing_doc["metadata"]["file_name"]:
+                        curr_doc = existing_doc
+                        break
+
+                if file_info.edit_type == EDIT_TYPE.DELETED:
+                    # Deleted files will be marked for deletion
+                    deleted_docs.append(curr_doc)
+                elif file_info.edit_type == EDIT_TYPE.MODIFIED or file_info.edit_type == EDIT_TYPE.RENAMED:
+                    # Modified files will be updated
+                    doc["text"] = git_provider.get_pr_file_content(file_info.filename, git_provider.get_pr_branch())
+                    doc["metadata"]["file_name"] = file_info.filename
+                    update_docs.append(doc)
+                elif file_info.edit_type == EDIT_TYPE.ADDED:
+                    # Added files will be created
+                    doc = {
+                        "text": git_provider.get_pr_file_content(file_info.filename, git_provider.get_pr_branch()),
+                        "metadata": {
+                            "file_name": file_info.filename,
+                        }
+                    }
+
+                    if file_info.language and file_info.language in self.valid_languages:
+                        # will likely need to make a map of github languages to tree sitter languages
+                        doc["metadata"]["language"] = file_info.language
+                        doc["metadata"]["split_type"] = "code"
+                    
+                    create_docs.append(doc)
+                else:
+                    # Unknown edit type, handle as needed
+                    get_logger().warning(f"Unknown edit type for file {file_info.filename}: {file_info.edit_type}")
+                    continue
+            
+            if not deleted_docs and not update_docs and not create_docs:
+                get_logger().info(f"No changes detected for PR URL {pr_url}.")
+                return
+
+            if for_base_branch:
+                print(f"Updating base branch index {base_index_name} for PR URL {pr_url}.")
+                # If this is a base branch update, we need to delete the old index
+                if deleted_docs:
+                    print(f"Deleting documents from base index {base_index_name} for PR URL {pr_url}.")
+                    resp = self.rag_client.delete_documents(base_index_name, [doc["doc_id"] for doc in deleted_docs])
+                    print(f"Deleted documents: {resp}")
+                if update_docs:
+                    print(f"Updating documents in base index {base_index_name} for PR URL {pr_url}.")
+                    resp = self.rag_client.update_documents(base_index_name, update_docs)
+                    print(f"Updated documents: {resp}")
+                if create_docs:
+                    print(f"Creating documents in base index {base_index_name} for PR URL {pr_url}.")
+                    resp = self.rag_client.index_documents(base_index_name, create_docs)
+                    print(f"Created documents: {resp}")
+            else:
+                print(f"Updating index {index_name} for PR URL {pr_url}.")
+                if deleted_docs:
+                    print(f"Deleting documents from index {index_name} for PR URL {pr_url}.")
+                    resp = self.rag_client.delete_documents(index_name, [doc["doc_id"] for doc in deleted_docs])
+                    print(f"Deleted documents: {resp}")
+                if update_docs:
+                    print(f"Updating documents in index {index_name} for PR URL {pr_url}.")
+                    resp = self.rag_client.update_documents(index_name, update_docs)
+                    print(f"Updated documents: {resp}")
+                if create_docs:
+                    print(f"Creating documents in index {index_name} for PR URL {pr_url}.")
+                    resp = self.rag_client.index_documents(index_name, create_docs)
+                    print(f"Created documents: {resp}")
+        except Exception as e:
+            get_logger().error(f"Error updating documents: {e}")
+            raise e
+


### PR DESCRIPTION
This adds support for using the KAITO RAGEngine within the PRReviewer.
- Creates new indexes on PR Open
- Updated indexes on new pushes to PR's
- Creates indexes for base branches (main)
- Updates indexes for base branches when PR's close